### PR TITLE
Fix bug for recipes with an apostrophe in title

### DIFF
--- a/src/classes/Pantry.js
+++ b/src/classes/Pantry.js
@@ -34,7 +34,7 @@ class Pantry {
       return arr
     }, [])
 
-      /// break here
+      /// see line 69 for how this connects
 
     const neededIngredients = recipe.ingredients.filter(ingredient => !isCookable.includes(ingredient));
 
@@ -65,13 +65,13 @@ class Pantry {
       return `${name}: ${sumNeededIngredients[index]}`
     })
 
-
+    console.log(isCookable.length, recipe.ingredients.length)
     if (isCookable.length === recipe.ingredients.length) {
       console.log("Yes! You can cook this recipe");
-      return "Yes! You can cook this recipe";
+      return `Yes! You can cook this recipe`;
     } else {
-      console.log(`Sorry! You don't have enough ingredients to cook ${recipe.name}. you need: ${formattedNameAndSum.join("\n")}.`)
-      return `Sorry! You don't have enough ingredients to cook ${recipe.name}. you need: ${formattedNameAndSum.join("\n")}.`;
+      console.log(`Sorry! You don't have enough ingredients to cook ${recipe.name}. you need: ${formattedNameAndSum.join("\n \n")}.`)
+      return `Sorry! You don't have enough ingredients to cook ${recipe.name}. you need: ${formattedNameAndSum.join("\n \n")}.`;
     }
   }
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -163,8 +163,8 @@ function populateSavedRecipesView() {
       id='${recipe.id}' src='${recipe.image}' alt='${recipe.name}'>
       <div class='saved-recipe-info-bar'>
         <p class='recipe-label'>${recipe.name}</p>
-        <img class='recipe-check-button' src='./check.svg.png' id='${recipe.name}'>
-        <img class='trash-can' src='./trash.png' alt='click this trash can to throw away ${recipe.name}'>
+        <img class='recipe-check-button' src='./check.svg.png' id= '${recipe.image}'>
+        <img class='trash-can' src='./trash.png' alt='click this trash can to throw away ${recipe.image}'>
       </div>
     </section>`;
   })
@@ -476,7 +476,7 @@ function deleteRecipe(event) {
     event.target.closest('section').remove();
   }
   user.recipesToCook.forEach((recipe, index) => {
-    if (alt === `click this trash can to throw away ${recipe.name}`) {
+    if (alt === `click this trash can to throw away ${recipe.image}`) {
       user.recipesToCook.splice(index, 1)
     }
     if (user.recipesToCook.length === 0) {
@@ -491,7 +491,7 @@ function fireIngredientEvaluation(event) {
   if (event.target.classList.contains('recipe-check-button')) {
     let recipeToCheck = event.target.id
     recipeData.forEach(recipe => {
-      if (recipeToCheck === recipe.name) {
+      if (recipeToCheck === recipe.image) {
         smallPantryWindow.innerHTML = ''
         smallPantryWindow.innerHTML += `<p class="pantry-recipe-check-instructions">Click the green
           checkmark to check if you have enough ingredients in your


### PR DESCRIPTION
1. What's this PR do?
Reassigns the target properties of the check mark button and the trash can icon to be recipe.image instead of recipe.name. This way, it circumnavigates the issue of apostrophes being present in the name of the recipe breaking the HTML.